### PR TITLE
docs: Update Cloudflare quickstart with new CLI and GitHub template

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,8 +21,10 @@ npm install @package-broker/cli @package-broker/main
 Initialize a new PACKAGE.broker deployment.
 
 ```bash
-npx package-broker
+npx package-broker init
 ```
+
+**Note**: You can also use `npx package-broker` (without `init`) - both commands are equivalent.
 
 **What it does**:
 - Creates `wrangler.toml` from template
@@ -118,5 +120,6 @@ cp node_modules/@package-broker/main/wrangler.example.toml wrangler.toml
 - See [Cloudflare Quickstart](../getting-started/quickstart-cloudflare) for complete setup guide
 - Review [Configuration Reference](./configuration) for all options
 - Check [Roadmap](./roadmap) for upcoming CLI features
+
 
 

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -18,8 +18,8 @@ This page outlines planned features and improvements for PACKAGE.broker. Feature
 Interactive CLI that simplifies Cloudflare deployment to a single command:
 
 ```bash
-npm install @package-broker/cloudflare
-npx package-broker-cloudflare init --interactive
+npm install @package-broker/cli
+npx package-broker init --interactive
 ```
 
 **Features**:


### PR DESCRIPTION
## Summary

Updates the Cloudflare Workers quickstart guide to document the new interactive CLI and GitHub template repository deployment methods.

## Changes

- Document new interactive CLI deployment method
- Add GitHub template repository deployment option
- Add API token permissions note with required scopes
- Update security practices (secrets not in wrangler.toml)
- Remove "Coming Soon" placeholders
- Add comprehensive troubleshooting section

## Key Updates

1. **Two deployment methods**:
   - Interactive CLI (recommended)
   - GitHub Template (CI/CD)

2. **API Token Permissions**: Clear documentation of required permissions

3. **Security**: Emphasis on secrets management via Cloudflare secrets

## Related

- Part of the enhanced Cloudflare deployment initiative
- Complements the new CLI package (package-broker/server PR)