### PR TITLE
docs: add SMTP email configuration documentation

### DIFF
--- a/docs/administration/tokens.md
+++ b/docs/administration/tokens.md
@@ -154,10 +154,20 @@ Tokens are rate-limited to prevent abuse:
 - Wait for rate limit reset
 - Consider increasing rate limit
 
+## User Invitations
+
+When creating new users via the dashboard, the system can automatically send invitation emails if SMTP is configured. Invitation emails include:
+
+- **Invite token flow**: A secure link to accept the invitation and set a password
+- **Temporary password flow**: A temporary password (if provided by admin)
+
+**Note**: Email sending requires SMTP configuration. See [Configuration Reference](../reference/configuration#email-configuration-smtp) for setup instructions. If SMTP is not configured, user creation will still work, but no emails will be sent.
+
 ## Next Steps
 
 - Review [Composer 101](../getting-started/composer-101) for authentication basics
 - See [E-shop Integration](../use-cases/eshop-extension-vendor) for automated token provisioning
 - Check [API Reference](../reference/api) for programmatic token management (planned)
+- Configure [SMTP](../reference/configuration#email-configuration-smtp) for user invitation emails
 
 

--- a/docs/getting-started/quickstart-cloudflare.md
+++ b/docs/getting-started/quickstart-cloudflare.md
@@ -56,6 +56,7 @@ After running `npx package-broker init`, follow the displayed instructions to:
 1. **Edit `wrangler.toml`** with your configuration:
    - Set your worker name
    - Configure encryption key (generate with: `openssl rand -base64 32`)
+   - Optionally configure SMTP for email sending (see [SMTP Configuration](#smtp-configuration-optional) below)
 
 2. **Login to Cloudflare**:
    ```bash
@@ -75,12 +76,18 @@ After running `npx package-broker init`, follow the displayed instructions to:
    $ npx wrangler secret put ENCRYPTION_KEY
    ```
 
-6. **Apply database migrations**:
+6. **Set SMTP secrets** (optional, for email sending):
+   ```bash
+   $ npx wrangler secret put SMTP_PASS
+   ```
+   See [SMTP Configuration](#smtp-configuration-optional) below for details.
+
+7. **Apply database migrations**:
    ```bash
    $ npx wrangler d1 migrations apply <worker-name>-db --remote
    ```
 
-7. **Deploy to Cloudflare**:
+8. **Deploy to Cloudflare**:
    ```bash
    $ npx wrangler deploy
    ```
@@ -235,6 +242,73 @@ The `ENCRYPTION_KEY` is **never stored in `wrangler.toml`**. It's set as a Cloud
 To update the key:
 - Via CLI: `wrangler secret put ENCRYPTION_KEY`
 - Via Dashboard: Workers & Pages → Settings → Variables and Secrets
+
+## SMTP Configuration (Optional)
+
+To enable email sending for user invitations, configure SMTP in `wrangler.toml`:
+
+```toml
+[vars]
+# ... existing vars ...
+SMTP_HOST = "smtp.sendgrid.net"
+SMTP_PORT = "587"
+SMTP_USER = "apikey"
+SMTP_FROM = "noreply@example.com"
+```
+
+**Important**: For production, store `SMTP_PASS` as a Cloudflare secret instead of in `[vars]`:
+
+```bash
+$ npx wrangler secret put SMTP_PASS
+```
+
+When prompted, enter your SMTP password or API key.
+
+### Email Provider Examples
+
+#### SendGrid (Recommended for Cloudflare)
+```toml
+[vars]
+SMTP_HOST = "smtp.sendgrid.net"
+SMTP_PORT = "587"
+SMTP_USER = "apikey"
+SMTP_FROM = "noreply@yourdomain.com"
+```
+Then set the API key as a secret:
+```bash
+$ npx wrangler secret put SMTP_PASS
+# Enter: SG.your-sendgrid-api-key
+```
+
+#### Gmail
+```toml
+[vars]
+SMTP_HOST = "smtp.gmail.com"
+SMTP_PORT = "587"
+SMTP_USER = "your-email@gmail.com"
+SMTP_FROM = "your-email@gmail.com"
+```
+Then set the app-specific password as a secret:
+```bash
+$ npx wrangler secret put SMTP_PASS
+```
+
+**Note**: Gmail requires an [app-specific password](https://support.google.com/accounts/answer/185833) for SMTP.
+
+#### AWS SES
+```toml
+[vars]
+SMTP_HOST = "email-smtp.us-east-1.amazonaws.com"
+SMTP_PORT = "587"
+SMTP_USER = "AKIAIOSFODNN7EXAMPLE"
+SMTP_FROM = "noreply@yourdomain.com"
+```
+Then set the IAM secret access key as a secret:
+```bash
+$ npx wrangler secret put SMTP_PASS
+```
+
+**Note**: Email sending is optional. If SMTP is not configured, user creation will still work, but no emails will be sent. See [Configuration Reference](../reference/configuration#email-configuration-smtp) for complete SMTP documentation.
 
 ## Initial Setup
 

--- a/docs/getting-started/quickstart-kubernetes.md
+++ b/docs/getting-started/quickstart-kubernetes.md
@@ -23,6 +23,7 @@ PACKAGE.broker will support deployment on Kubernetes using an official Helm char
 - Configurable resource limits
 - Support for PostgreSQL, Redis, S3-compatible storage
 - Ingress configuration templates
+- SMTP email configuration for user invitations
 
 ### Deployment Options
 
@@ -30,6 +31,24 @@ PACKAGE.broker will support deployment on Kubernetes using an official Helm char
 - **Redis**: Caching and session storage
 - **S3-compatible**: Object storage for artifacts
 - **Horizontal scaling**: Multiple pod replicas
+- **SMTP**: Email configuration for user invitations and notifications
+
+### SMTP Configuration
+
+The Helm chart will support SMTP configuration via `values.yaml`:
+
+```yaml
+config:
+  smtp:
+    host: "smtp.gmail.com"
+    port: "587"
+    user: "your-email@gmail.com"
+    from: "noreply@example.com"
+    existingSecret: "smtp-credentials"  # Use existing Kubernetes secret
+    passwordKey: "smtp-password"        # Key in secret for password
+```
+
+**Note**: Store SMTP passwords in Kubernetes secrets, not directly in `values.yaml`. See the [Helm chart values.yaml](https://github.com/package-broker/server/blob/main/charts/package-broker/values.yaml) for the complete SMTP configuration structure.
 
 ## Timeline
 

--- a/docs/installation/docker-compose.md
+++ b/docs/installation/docker-compose.md
@@ -30,6 +30,12 @@ services:
       S3_ENDPOINT: minio:9000
       S3_BUCKET: packages
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      # SMTP Configuration (Optional - uncomment to enable email sending)
+      # SMTP_HOST: ${SMTP_HOST}
+      # SMTP_PORT: ${SMTP_PORT:-587}
+      # SMTP_USER: ${SMTP_USER}
+      # SMTP_PASS: ${SMTP_PASS}
+      # SMTP_FROM: ${SMTP_FROM}
     depends_on:
       - postgres
       - redis
@@ -74,6 +80,14 @@ Create a `.env` file:
 ENCRYPTION_KEY=$(openssl rand -base64 32)
 DB_PASSWORD=your-secure-password
 MINIO_ROOT_PASSWORD=your-secure-password
+
+# SMTP Configuration (Optional)
+# Uncomment and configure to enable email sending for user invitations
+# SMTP_HOST=smtp.gmail.com
+# SMTP_PORT=587
+# SMTP_USER=your-email@gmail.com
+# SMTP_PASS=your-app-password
+# SMTP_FROM=noreply@example.com
 ```
 
 ### Starting Services
@@ -98,11 +112,31 @@ services:
     image: ghcr.io/package-broker/server:latest
 ```
 
+## SMTP Configuration (Optional)
+
+To enable email sending for user invitations, configure SMTP settings:
+
+1. Add SMTP variables to your `.env` file (see [Environment Variables](#environment-variables) above)
+2. Uncomment the SMTP environment variables in `docker-compose.yml`
+3. Restart the container: `docker-compose restart package-broker`
+
+**Example for Gmail**:
+```bash
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=your-email@gmail.com
+SMTP_PASS=your-app-specific-password
+SMTP_FROM=your-email@gmail.com
+```
+
+**Note**: Gmail requires an [app-specific password](https://support.google.com/accounts/answer/185833) for SMTP. See [Configuration Reference](../reference/configuration#email-configuration-smtp) for other email provider examples.
+
 ## Next Steps
 
 1. Review the [Docker Quickstart guide](../getting-started/quickstart-docker.md) for detailed setup instructions
 2. Check the [Cloudflare Workers Quickstart](../getting-started/quickstart-cloudflare.md) for serverless deployment options
 3. Review [compliance documentation](../soc2-compliance.md)
+4. Configure SMTP for email notifications (see [SMTP Configuration](#smtp-configuration-optional) above)
 
 ## Support
 

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -48,6 +48,55 @@ After starting the container:
 1. Review the [Docker Quickstart guide](../getting-started/quickstart-docker.md) for detailed setup instructions
 2. Check the [Cloudflare Workers Quickstart](../getting-started/quickstart-cloudflare.md) for serverless deployment options
 
+## SMTP Configuration (Optional)
+
+To enable email sending for user invitations, configure SMTP environment variables:
+
+```bash
+docker run -d \
+  -p 8080:8080 \
+  -v $(pwd)/data:/data \
+  -e ENCRYPTION_KEY=$(openssl rand -base64 32) \
+  -e SMTP_HOST=smtp.gmail.com \
+  -e SMTP_PORT=587 \
+  -e SMTP_USER=your-email@gmail.com \
+  -e SMTP_PASS=your-app-password \
+  -e SMTP_FROM=noreply@example.com \
+  packagebroker/server:latest
+```
+
+### Email Provider Examples
+
+#### Gmail
+```bash
+-e SMTP_HOST=smtp.gmail.com \
+-e SMTP_PORT=587 \
+-e SMTP_USER=your-email@gmail.com \
+-e SMTP_PASS=your-app-specific-password \
+-e SMTP_FROM=your-email@gmail.com
+```
+**Note**: Gmail requires an [app-specific password](https://support.google.com/accounts/answer/185833) for SMTP authentication.
+
+#### SendGrid
+```bash
+-e SMTP_HOST=smtp.sendgrid.net \
+-e SMTP_PORT=587 \
+-e SMTP_USER=apikey \
+-e SMTP_PASS=SG.your-sendgrid-api-key \
+-e SMTP_FROM=noreply@yourdomain.com
+```
+
+#### AWS SES
+```bash
+-e SMTP_HOST=email-smtp.us-east-1.amazonaws.com \
+-e SMTP_PORT=587 \
+-e SMTP_USER=AKIAIOSFODNN7EXAMPLE \
+-e SMTP_PASS=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+-e SMTP_FROM=noreply@yourdomain.com
+```
+
+**Note**: Email sending is optional. If SMTP is not configured, user creation will still work, but no emails will be sent. See [Configuration Reference](../reference/configuration#email-configuration-smtp) for complete SMTP documentation.
+
 ## Production Considerations
 
 For production deployments, see the [Docker Compose guide](./docker-compose.md) for:
@@ -56,6 +105,7 @@ For production deployments, see the [Docker Compose guide](./docker-compose.md) 
 - S3-compatible storage
 - SSL/TLS configuration
 - Backup procedures
+- SMTP email configuration
 
 ## Support
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -235,6 +235,152 @@ LOG_LEVEL=debug
 NODE_ENV=production
 ```
 
+## Email Configuration (SMTP)
+
+SMTP configuration enables email sending for user invitations and notifications. Email sending is **optional** - if SMTP is not configured, user creation will still work, but no emails will be sent.
+
+### SMTP_HOST
+
+**Type**: `string`  
+**Required**: Yes (for email functionality)  
+**Description**: SMTP server hostname.
+
+**Examples**:
+- Gmail: `smtp.gmail.com`
+- SendGrid: `smtp.sendgrid.net`
+- AWS SES: `email-smtp.us-east-1.amazonaws.com`
+- Mailgun: `smtp.mailgun.org`
+- Custom: `mail.example.com`
+
+### SMTP_PORT
+
+**Type**: `string`  
+**Required**: No  
+**Default**: `587`  
+**Description**: SMTP server port.
+
+**Common Values**:
+- `587` - STARTTLS (recommended for most providers)
+- `465` - SSL/TLS (automatically enabled)
+- `25` - Unencrypted (not recommended for production)
+
+**Example**:
+```bash
+SMTP_PORT=587
+```
+
+### SMTP_USER
+
+**Type**: `string`  
+**Required**: Yes (for email functionality)  
+**Description**: SMTP authentication username.
+
+**Examples**:
+- Gmail: Your Gmail address (e.g., `your-email@gmail.com`)
+- SendGrid: `apikey` (literal string)
+- AWS SES: IAM access key ID
+- Mailgun: Your Mailgun account email
+- Custom: SMTP username provided by your email provider
+
+### SMTP_PASS
+
+**Type**: `string`  
+**Required**: Yes (for email functionality)  
+**Description**: SMTP authentication password or API key.
+
+**Security**: Store as environment variable or secret. Never commit to version control.
+
+**Examples**:
+- Gmail: App-specific password (not your regular Gmail password)
+- SendGrid: API key from SendGrid dashboard
+- AWS SES: IAM secret access key
+- Mailgun: API key from Mailgun dashboard
+- Custom: SMTP password provided by your email provider
+
+### SMTP_FROM
+
+**Type**: `string`  
+**Required**: No  
+**Default**: Value of `SMTP_USER`  
+**Description**: "From" email address displayed in sent emails.
+
+**Examples**:
+```bash
+SMTP_FROM=noreply@example.com
+SMTP_FROM="Package Broker <noreply@example.com>"
+```
+
+**Note**: Some email providers require the "From" address to match your verified domain or account.
+
+### Email Functionality
+
+When SMTP is configured (`SMTP_HOST`, `SMTP_USER`, and `SMTP_PASS` are set), the system will:
+- Automatically send invitation emails when admins create new users
+- Include invitation links or temporary passwords in emails
+- Use HTML email templates for better formatting
+
+**Note**: Email sending is optional. If SMTP is not configured, user creation will still work, but no emails will be sent. Email failures are logged but don't block user creation.
+
+### Email Provider Examples
+
+#### Gmail
+
+```bash
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=your-email@gmail.com
+SMTP_PASS=your-app-specific-password
+SMTP_FROM=your-email@gmail.com
+```
+
+**Note**: Gmail requires an [app-specific password](https://support.google.com/accounts/answer/185833) for SMTP authentication. Regular passwords won't work.
+
+#### SendGrid
+
+```bash
+SMTP_HOST=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_USER=apikey
+SMTP_PASS=SG.your-sendgrid-api-key
+SMTP_FROM=noreply@yourdomain.com
+```
+
+**Note**: SendGrid uses `apikey` as the username and your API key as the password.
+
+#### AWS SES
+
+```bash
+SMTP_HOST=email-smtp.us-east-1.amazonaws.com
+SMTP_PORT=587
+SMTP_USER=AKIAIOSFODNN7EXAMPLE
+SMTP_PASS=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+SMTP_FROM=noreply@yourdomain.com
+```
+
+**Note**: Use IAM credentials with SES SMTP access. Ensure your domain/email is verified in SES.
+
+#### Mailgun
+
+```bash
+SMTP_HOST=smtp.mailgun.org
+SMTP_PORT=587
+SMTP_USER=postmaster@mg.yourdomain.com
+SMTP_PASS=your-mailgun-smtp-password
+SMTP_FROM=noreply@yourdomain.com
+```
+
+**Note**: Mailgun provides SMTP credentials in the dashboard under Sending → Domain Settings.
+
+#### Custom SMTP Server
+
+```bash
+SMTP_HOST=mail.example.com
+SMTP_PORT=587
+SMTP_USER=your-username
+SMTP_PASS=your-password
+SMTP_FROM=noreply@example.com
+```
+
 ## Cloudflare-Specific Configuration
 
 ### Workers Bindings


### PR DESCRIPTION
## Summary

This PR adds comprehensive SMTP email configuration documentation to the project. The SMTP feature was already implemented but lacked documentation, making it difficult for users to configure email sending for user invitations.

## Changes

### Documentation Updates

1. **Configuration Reference** (`docs/reference/configuration.md`)
   - Added complete "Email Configuration (SMTP)" section
   - Documented all environment variables: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`
   - Included email provider examples (Gmail, SendGrid, AWS SES, Mailgun, Custom)
   - Added security notes and usage information

2. **Docker Installation Guide** (`docs/installation/docker.md`)
   - Added SMTP configuration section with examples
   - Included provider-specific examples for Gmail, SendGrid, and AWS SES

3. **Docker Compose Guide** (`docs/installation/docker-compose.md`)
   - Added SMTP environment variables to `.env` file example
   - Updated `docker-compose.yml` example with SMTP configuration
   - Added dedicated SMTP configuration section

4. **Cloudflare Quickstart** (`docs/getting-started/quickstart-cloudflare.md`)
   - Added SMTP configuration to `wrangler.toml` examples
   - Explained using Cloudflare Workers secrets for `SMTP_PASS`
   - Included provider-specific examples (SendGrid, Gmail, AWS SES)

5. **Kubernetes Quickstart** (`docs/getting-started/quickstart-kubernetes.md`)
   - Added SMTP configuration to planned Helm chart features
   - Included `values.yaml` example for SMTP configuration

6. **Administration Documentation** (`docs/administration/tokens.md`)
   - Added note about user invitation emails
   - Explained when emails are sent and SMTP requirements

## Environment Variables Documented

- `SMTP_HOST` (required) - SMTP server hostname
- `SMTP_PORT` (optional, default: 587) - SMTP server port
- `SMTP_USER` (required) - SMTP authentication username
- `SMTP_PASS` (required) - SMTP authentication password/API key
- `SMTP_FROM` (optional, default: SMTP_USER) - "From" email address

## Email Provider Examples

Documentation includes examples for:
- Gmail (with app-specific password instructions)
- SendGrid (with API key setup)
- AWS SES (with IAM credentials)
- Mailgun (with SMTP credentials)
- Custom SMTP servers

## Related

- SMTP feature implementation: `server/packages/core/src/services/EmailService.ts`
- User invitation handler: `server/packages/core/src/modules/users/users.handlers.ts`

## Testing

Documentation has been reviewed for:
- ✅ Accuracy of environment variable names
- ✅ Consistency across all deployment methods
- ✅ Security best practices (secrets, not plaintext)
- ✅ Provider-specific requirements (e.g., Gmail app passwords)

## Notes

- Email sending is **optional** - system works without SMTP
- Email failures are logged but don't block user creation
- Currently only supports user invitation emails