### PR TITLE
Clarify deployment status copy

### DIFF
--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -10,7 +10,7 @@ interface FAQItem {
 const faqItems: FAQItem[] = [
   {
     question: 'Is Cloudflare free tier enough for my team?',
-    answer: 'Yes! Cloudflare Workers free tier includes 100,000 requests per day, which is sufficient for most small agencies. For larger teams, you can upgrade to Cloudflare Workers Paid ($5/month) or deploy on Docker/Kubernetes for unlimited usage.',
+    answer: 'Yes! Cloudflare Workers free tier includes 100,000 requests per day, which is sufficient for most small agencies. For larger teams, you can upgrade to Cloudflare Workers Paid ($5/month). Docker and Kubernetes are mentioned in the roadmap, but are not presented as the default path yet.',
   },
   {
     question: 'How do authentication tokens work?',
@@ -75,4 +75,3 @@ export default function FAQ() {
     </div>
   );
 }
-

--- a/src/components/PlatformGrid.tsx
+++ b/src/components/PlatformGrid.tsx
@@ -18,8 +18,7 @@ const platforms: Platform[] = [
     name: 'Docker',
     description: '1-Click Setup',
     icon: <Box size={32} />,
-    status: 'available',
-    link: '/docs/getting-started/quickstart-docker',
+    status: 'coming-soon',
     bestFor: 'Self-hosted deployments',
   },
   {
@@ -100,10 +99,9 @@ export default function PlatformGrid() {
       </div>
       <div className={styles.roadmapFooter}>
         <p className={styles.roadmapText}>
-          <strong>Roadmap:</strong> Kubernetes deployment is planned for Q2 2025. Docker and Cloudflare Workers are available now.
+          <strong>Roadmap:</strong> Cloudflare Workers is available now. Docker and Kubernetes are still listed as planned/in development in the docs.
         </p>
       </div>
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary

- mark Docker as coming soon in the deployment grid
- remove the stale Kubernetes Q2 2025 roadmap wording
- align the Cloudflare FAQ answer with the existing Docker/Kubernetes status FAQ

## Why

The homepage currently presents Docker as available, while the FAQ says Docker and Kubernetes are still in active development. This keeps the public deployment status wording consistent.

## Validation

```bash
npm run build
```

Build passes. Docusaurus still reports an existing broken link warning for `/docs/reference/api -> /api/swagger`, which is unrelated to this copy change.

```bash
npm run typecheck
```

Typecheck is currently blocked by existing TypeScript errors in `src/remark/responsive-images.ts` and `src/theme/Navbar/MobileSidebar/PrimaryMenu/index.tsx`, unrelated to this change.
